### PR TITLE
Use pull_request for formatting workflow

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -10,7 +10,7 @@ on:
     types: [opened, edited]
   discussion:
     types: [created]
-  pull_request_target:
+  pull_request:
     types: [opened, closed, synchronize, review_requested]
 
 permissions:


### PR DESCRIPTION
## Summary

Use the standard `pull_request` event for the formatting workflow instead of `pull_request_target`.

External fork formatting remains handled by the Ultralytics GitHub App without exposing base-repository secrets to fork code.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

🔒 Updates the formatting workflow to use the safer `pull_request` event instead of `pull_request_target`.

### 📊 Key Changes

- Changed the GitHub Actions trigger from `pull_request_target` to `pull_request`.
- Preserved the existing pull request activity types: opened, closed, synchronized, and review requested.

### 🎯 Purpose & Impact

- 🛡️ Improves workflow security by running against the pull request context rather than the target branch context.
- 🔐 Reduces the risk of untrusted pull request code accessing repository-level secrets or permissions.
- ✅ Keeps formatting checks running for the same pull request events, with potentially different behavior for contributions from forks due to GitHub Actions security restrictions.