### PR TITLE
Add social icons footer to Chinese README

### DIFF
--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -126,3 +126,20 @@ YOLO11 使用指南请先查看 [YOLO11 文档](https://docs.ultralytics.com/zh/
 
 如有疑问、讨论和社区支持，请加入 [Discord](https://discord.com/invite/ultralytics)、[Reddit](https://www.reddit.com/r/ultralytics/)
 和 [Ultralytics 社区论坛](https://community.ultralytics.com/)。
+
+<br>
+<div align="center">
+  <a href="https://github.com/ultralytics"><img src="https://github.com/ultralytics/assets/raw/main/social/logo-social-github.png" width="3%" alt="Ultralytics GitHub"></a>
+  <img src="https://github.com/ultralytics/assets/raw/main/social/logo-transparent.png" width="3%" alt="space">
+  <a href="https://www.linkedin.com/company/ultralytics/"><img src="https://github.com/ultralytics/assets/raw/main/social/logo-social-linkedin.png" width="3%" alt="Ultralytics LinkedIn"></a>
+  <img src="https://github.com/ultralytics/assets/raw/main/social/logo-transparent.png" width="3%" alt="space">
+  <a href="https://twitter.com/ultralytics"><img src="https://github.com/ultralytics/assets/raw/main/social/logo-social-twitter.png" width="3%" alt="Ultralytics Twitter"></a>
+  <img src="https://github.com/ultralytics/assets/raw/main/social/logo-transparent.png" width="3%" alt="space">
+  <a href="https://www.youtube.com/ultralytics?sub_confirmation=1"><img src="https://github.com/ultralytics/assets/raw/main/social/logo-social-youtube.png" width="3%" alt="Ultralytics YouTube"></a>
+  <img src="https://github.com/ultralytics/assets/raw/main/social/logo-transparent.png" width="3%" alt="space">
+  <a href="https://www.tiktok.com/@ultralytics"><img src="https://github.com/ultralytics/assets/raw/main/social/logo-social-tiktok.png" width="3%" alt="Ultralytics TikTok"></a>
+  <img src="https://github.com/ultralytics/assets/raw/main/social/logo-transparent.png" width="3%" alt="space">
+  <a href="https://ultralytics.com/bilibili"><img src="https://github.com/ultralytics/assets/raw/main/social/logo-social-bilibili.png" width="3%" alt="Ultralytics BiliBili"></a>
+  <img src="https://github.com/ultralytics/assets/raw/main/social/logo-transparent.png" width="3%" alt="space">
+  <a href="https://discord.com/invite/ultralytics"><img src="https://github.com/ultralytics/assets/raw/main/social/logo-social-discord.png" width="3%" alt="Ultralytics Discord"></a>
+</div>


### PR DESCRIPTION
`README.zh-CN.md` ended at the Contact section while `README.md` closes with the standard Ultralytics social icons footer. Appended the same footer block verbatim so both READMEs match.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

🌐 Adds a centered social media links section to the Chinese README.

### 📊 Key Changes

- Added linked icons for Ultralytics’:
  - GitHub
  - LinkedIn
  - Twitter
  - YouTube
  - TikTok
  - BiliBili
  - Discord
- Positioned the links at the bottom of `README.zh-CN.md`.
- Used consistent spacing, sizing, and accessible image descriptions.

### 🎯 Purpose & Impact

- 🤝 Makes Ultralytics’ Chinese-speaking community and social channels easier to discover.
- 📣 Improves README engagement without changing any code, models, or functionality.
- 🇨🇳 Strengthens community outreach for Chinese users through BiliBili and existing global platforms.