### PR TITLE
Remove trailing slashes and update redirected Ultralytics URLs

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -9,11 +9,11 @@ contact_links:
     url: https://github.com/ultralytics/ultralytics/issues
     about: Report bugs in the ultralytics Python package or yolo CLI
   - name: 💬 Forum
-    url: https://community.ultralytics.com/
+    url: https://community.ultralytics.com
     about: Ask on Ultralytics Community Forum
   - name: 🎧 Discord
     url: https://ultralytics.com/discord
     about: Ask on Ultralytics Discord
   - name: ⌨️ Reddit
-    url: https://reddit.com/r/ultralytics
+    url: https://www.reddit.com/r/ultralytics/
     about: Ask on Ultralytics Subreddit

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
     <a href="https://github.com/ultralytics/ultralytics/actions/workflows/ci.yml"><img src="https://github.com/ultralytics/ultralytics/actions/workflows/ci.yml/badge.svg" alt="Ultralytics CI"></a>
     <a href="https://clickpy.clickhouse.com/dashboard/ultralytics"><img src="https://static.pepy.tech/badge/ultralytics" alt="Ultralytics Downloads"></a>
     <a href="https://discord.com/invite/ultralytics"><img alt="Ultralytics Discord" src="https://img.shields.io/discord/1089800235347353640?logo=discord&logoColor=white&label=Discord&color=blue"></a>
-    <a href="https://community.ultralytics.com/"><img alt="Ultralytics Forums" src="https://img.shields.io/discourse/users?server=https%3A%2F%2Fcommunity.ultralytics.com&logo=discourse&label=Forums&color=blue"></a>
+    <a href="https://community.ultralytics.com"><img alt="Ultralytics Forums" src="https://img.shields.io/discourse/users?server=https%3A%2F%2Fcommunity.ultralytics.com&logo=discourse&label=Forums&color=blue"></a>
     <a href="https://www.reddit.com/r/ultralytics/"><img alt="Ultralytics Reddit" src="https://img.shields.io/reddit/subreddit-subscribers/ultralytics?style=flat&logo=reddit&logoColor=white&label=Reddit&color=blue"></a>
     <br>
     <a href="https://console.paperspace.com/github/ultralytics/ultralytics"><img src="https://assets.paperspace.io/img/gradient-badge.svg" alt="Run Ultralytics on Gradient"></a>
@@ -20,7 +20,7 @@
 </div>
 <br>
 
-[Ultralytics](https://www.ultralytics.com/) [YOLO11](https://docs.ultralytics.com/models/yolo11) is available
+[Ultralytics](https://www.ultralytics.com) [YOLO11](https://docs.ultralytics.com/models/yolo11) is available
 through the official [Ultralytics YOLO](https://github.com/ultralytics/ultralytics) package. It supports object
 detection, instance segmentation, image classification, pose estimation, oriented object detection, and tracking in a
 fast, accurate, and easy to use Python and CLI workflow.
@@ -151,7 +151,7 @@ or upgrade the [Ultralytics Python package](https://pypi.org/project/ultralytics
 
 For questions, discussions, and community support, join our active communities on
 [Discord](https://discord.com/invite/ultralytics), [Reddit](https://www.reddit.com/r/ultralytics/), and the
-[Ultralytics Community Forums](https://community.ultralytics.com/).
+[Ultralytics Community Forums](https://community.ultralytics.com).
 
 <br>
 <div align="center">

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -10,7 +10,7 @@
     <a href="https://github.com/ultralytics/ultralytics/actions/workflows/ci.yml"><img src="https://github.com/ultralytics/ultralytics/actions/workflows/ci.yml/badge.svg" alt="Ultralytics CI"></a>
     <a href="https://clickpy.clickhouse.com/dashboard/ultralytics"><img src="https://static.pepy.tech/badge/ultralytics" alt="Ultralytics Downloads"></a>
     <a href="https://discord.com/invite/ultralytics"><img alt="Ultralytics Discord" src="https://img.shields.io/discord/1089800235347353640?logo=discord&logoColor=white&label=Discord&color=blue"></a>
-    <a href="https://community.ultralytics.com/"><img alt="Ultralytics Forums" src="https://img.shields.io/discourse/users?server=https%3A%2F%2Fcommunity.ultralytics.com&logo=discourse&label=Forums&color=blue"></a>
+    <a href="https://community.ultralytics.com"><img alt="Ultralytics Forums" src="https://img.shields.io/discourse/users?server=https%3A%2F%2Fcommunity.ultralytics.com&logo=discourse&label=Forums&color=blue"></a>
     <a href="https://www.reddit.com/r/ultralytics/"><img alt="Ultralytics Reddit" src="https://img.shields.io/reddit/subreddit-subscribers/ultralytics?style=flat&logo=reddit&logoColor=white&label=Reddit&color=blue"></a>
     <br>
     <a href="https://console.paperspace.com/github/ultralytics/ultralytics"><img src="https://assets.paperspace.io/img/gradient-badge.svg" alt="Run Ultralytics on Gradient"></a>
@@ -20,7 +20,7 @@
 </div>
 <br>
 
-[Ultralytics](https://www.ultralytics.com/) [YOLO11](https://docs.ultralytics.com/zh/models/yolo11) 可通过官方
+[Ultralytics](https://www.ultralytics.com) [YOLO11](https://docs.ultralytics.com/zh/models/yolo11) 可通过官方
 [Ultralytics YOLO](https://github.com/ultralytics/ultralytics) 包使用，支持目标检测、实例分割、图像分类、姿态估计、旋转目标检测和跟踪，并提供快速、准确、易用的 Python 与 CLI 工作流。
 
 本仓库是 YOLO11 的轻量级发现入口。官方实现、软件包发布、模型下载、Issues 和 Pull Requests 均在
@@ -125,7 +125,7 @@ YOLO11 使用指南请先查看 [YOLO11 文档](https://docs.ultralytics.com/zh/
 > 提交错误报告和功能请求，方便维护者结合源代码统一分类处理。
 
 如有疑问、讨论和社区支持，请加入 [Discord](https://discord.com/invite/ultralytics)、[Reddit](https://www.reddit.com/r/ultralytics/)
-和 [Ultralytics 社区论坛](https://community.ultralytics.com/)。
+和 [Ultralytics 社区论坛](https://community.ultralytics.com)。
 
 <br>
 <div align="center">


### PR DESCRIPTION
Normalizes every Ultralytics URL in this repo to its canonical, redirect-free form.

## Trailing slashes (7 fixed, 3 files)

Removed the terminating path slash from all `ultralytics.com` / `*.ultralytics.com` URLs. Both hosts serve `200` directly on the slash-free form, so each edit removes a needless canonicalization hop:

| File | Occurrences |
| --- | --- |
| `README.md` | 3 |
| `README.zh-CN.md` | 3 |
| `.github/ISSUE_TEMPLATE/config.yml` | 1 |

Affected URLs: `https://www.ultralytics.com/` and `https://community.ultralytics.com/`.

The fix was applied with a regex validated against 15 positive and 15 negative cases first, so only slashes that *terminate a path* were touched — never path separators. Notable negatives that were correctly left alone:

- `https://img.shields.io/discourse/users?server=https%3A%2F%2Fcommunity.ultralytics.com&...` — the URL-encoded badge parameter stays byte-identical.
- `https://github.com/ultralytics/...` — `ultralytics` as a path segment, not a host.
- `https://www.reddit.com/r/ultralytics/` badge links — non-Ultralytics domain, out of scope.

## Redirect refresh (1 accepted, 2 rejected)

All 120 HTTP URLs in the repo were resolved (markdown links, HTML anchors, and the bare `url:` values in YAML/CFF that link-only collectors miss). Three redirects surfaced:

**Accepted**

- `https://reddit.com/r/ultralytics` → `https://www.reddit.com/r/ultralytics/` in `.github/ISSUE_TEMPLATE/config.yml`. A genuine two-hop `301` host canonicalization; the new value is byte-identical to the Reddit link both READMEs already use, so the repo is now internally consistent.

**Rejected**

- `https://ultralytics.com/discord` → `https://discord.com/invite/ultralytics`. Vanity shortlink whose target is an expiring invite — the shortlink is the durable form and must stay a redirect.
- `https://ultralytics.com/license` → `https://www.ultralytics.com/license`. This string appears only in the `# Ultralytics 🚀 AGPL-3.0 License` headers that Ultralytics Actions writes automatically; rewriting it would desync the files from the tool that regenerates them.

**Dead links:** none.

## Validation

- Full diff reviewed line by line — 8 changed lines, all URL text, no prose or structural edits.
- Zero `ultralytics.com` URLs retain a terminating slash after the sweep (re-verified).
- `prettier@3.8.5 --print-width 120 --check` on all Markdown/YAML: clean.
- `codespell`: clean.
- All six YAML files and `CITATION.cff` re-parsed successfully.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Updated repository links to use canonical Ultralytics and Reddit URLs, removing unnecessary redirects and aligning Reddit references across files.

### 📊 Key Changes

- Removed trailing slashes from `ultralytics.com` and `community.ultralytics.com` links in `README.md`, `README.zh-CN.md`, and `.github/ISSUE_TEMPLATE/config.yml`.
- Updated the issue template’s Reddit contact link from `https://reddit.com/r/ultralytics` to `https://www.reddit.com/r/ultralytics/`.
- Preserved the Discord shortlink and autogenerated license-header URLs, leaving their existing redirect behavior unchanged.
- Changed only eight URL lines; no prose or repository structure was modified.

### 🎯 Purpose & Impact

- Markdown badges, documentation links, community links, and issue-template contact links now use the repository’s canonical URL forms.
- No user-facing feature change.